### PR TITLE
Actual and expected values are fallback-ed to empty strings

### DIFF
--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -24,8 +24,8 @@ export function compare(operator: string, actualValue: string, value: string) {
   const dateTimeFormat = /\d{4}-\d{2}-\d{2}(?:.?\d{2}:\d{2}:\d{2})?/;
 
   operator = operator || '';
-  actualValue = actualValue || '';
-  value = value || '';
+  actualValue = actualValue === undefined || actualValue === null ? '' : actualValue;
+  value = value === undefined || value === null ? '' : value;
 
   if (validOperators.includes(operator.toLowerCase())) {
     if (operator == 'be') {

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -23,6 +23,7 @@ export function compare(operator: string, actualValue: string, value: string) {
   const validOperators = ['be', 'not be', 'contain', 'not contain', 'be greater than', 'be less than'];
   const dateTimeFormat = /\d{4}-\d{2}-\d{2}(?:.?\d{2}:\d{2}:\d{2})?/;
 
+  operator = operator || '';
   actualValue = actualValue || '';
   value = value || '';
 

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -23,6 +23,9 @@ export function compare(operator: string, actualValue: string, value: string) {
   const validOperators = ['be', 'not be', 'contain', 'not contain', 'be greater than', 'be less than'];
   const dateTimeFormat = /\d{4}-\d{2}-\d{2}(?:.?\d{2}:\d{2}:\d{2})?/;
 
+  actualValue = actualValue || '';
+  value = value || '';
+
   if (validOperators.includes(operator.toLowerCase())) {
     if (operator == 'be') {
       return actualValue == value;


### PR DESCRIPTION
Fix for #4 

Defaults both `expected` and `actual` values being compared to `empty string`