### PR TITLE
Add "be one of" and negated operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -952,6 +952,12 @@
       "integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "dev": true
+    },
     "@types/plugin-error": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@types/plugin-error/-/plugin-error-0.1.1.tgz",
@@ -2189,6 +2195,11 @@
           "dev": true
         }
       }
+    },
+    "csv-string": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.0.1.tgz",
+      "integrity": "sha512-nCdK+EWDbqLvZ2MmVQhHTmidMEsHbK3ncgTJb4oguNRpkmH5OOr+KkDRB4nqsVrJ7oK0AdO1QEsBp0+z7KBtGQ=="
     },
     "d": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "url": "https://github.com/run-crank/typescript-cog-utilities/issues"
   },
   "dependencies": {
+    "csv-string": "^4.0.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
     "@types/jest": "^23.3.1",
+    "@types/node": "^14.0.13",
     "@types/yosay": "^0.0.29",
     "del": "^3.0.0",
     "fancy-log": "^1.3.2",

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,5 +1,6 @@
 import { UnknownOperatorError, InvalidOperandError } from '../constants/errors';
 import * as moment from 'moment';
+import { parse as parseCsvString } from 'csv-string';
 
 export const operatorFailMessages: any = {
   'be': 'Expected %s field to be %s, but it was actually %s',
@@ -10,6 +11,8 @@ export const operatorFailMessages: any = {
   'be less than': '%s field is expected to be less than %s, but its value was %s',
   'be set': 'Expected %s field to be set, but it was not',
   'not be set': 'Expected %s field not to be set, but it was actually set to %s%s', // Note: %s%s is to ensure message is rendered with proper output; first %s is empty in this case.
+  'be one of': 'Expected %s field to be one of these values (%s), but it was actually %s',
+  'not be one of': 'Expected %s field to not be one of these values (%s), but it was actually %s',
 };
 
 export const operatorSuccessMessages: any = {
@@ -21,10 +24,12 @@ export const operatorSuccessMessages: any = {
   'be less than': 'The %s field was less than %s, as expected',
   'be set': '%s field was set, as expected',
   'not be set': '%s field was not set, as expected',
+  'be one of': '%s field was set to one of these values (%s), as expected',
+  'not be one of': '%s field was not set to one of these values (%s), as expected'
 };
 
 export function compare(operator: string, actualValue: any, value: string = null) {
-  const validOperators = ['be', 'not be', 'contain', 'not contain', 'be greater than', 'be less than', 'be set', 'not be set'];
+  const validOperators = ['be', 'not be', 'contain', 'not contain', 'be greater than', 'be less than', 'be set', 'not be set', 'be one of', 'not be one of'];
   const dateTimeFormat = /\d{4}-\d{2}-\d{2}(?:.?\d{2}:\d{2}:\d{2})?/;
 
   operator = operator || '';
@@ -60,6 +65,14 @@ export function compare(operator: string, actualValue: any, value: string = null
       return actualValue != '';
     } else if (operator.toLowerCase() == 'not be set') {
       return actualValue == '';
+    } else if (operator.toLowerCase() == 'be one of') {
+      return parseCsvString(value)[0]
+        .map(v => v.trim())
+        .includes(actualValue.trim());
+    } else if (operator.toLowerCase() == 'not be one of') {
+      return !parseCsvString(value)[0]
+        .map(v => v.trim())
+        .includes(actualValue.trim());
     }
   } else {
     throw new UnknownOperatorError(operator);

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -208,4 +208,58 @@ describe('testing compare function', () => {
       });
     });
   });
+  describe('testing be one of and not be one of operators', () => {
+    describe('be one of', () => {
+      test('compare be one of with a single value should return true', () => {
+        const operator = 'be one of';
+        const actualValue = 'xyz';
+        const value = 'xyz';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+      test('compare be one of with comma-separated values should return true', () => {
+        const operator = 'be one of';
+        const actualValue = 'xyz';
+        const value = 'abc,jkl,xyz,sdf';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+      test('compare be one of with comma and space separated values should return true', () => {
+        const operator = 'be one of';
+        const actualValue = 'xyz';
+        const value = 'abc, jkl, xyz, sdf';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+      test('compare be one of with quoted comma-separated values should return true', () => {
+        const operator = 'be one of';
+        const actualValue = 'x, yz';
+        const value = '"a bc", jkl, "x, yz"';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+    });
+    describe('not be one of', () => {
+      test('compare not be one of with a single value should return true', () => {
+        const operator = 'not be one of';
+        const actualValue = 'xyz';
+        const value = 'abc';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+      test('compare not be one of with comma-separated values should return true', () => {
+        const operator = 'not be one of';
+        const actualValue = 'xyz';
+        const value = 'abc,jkl,opq,sdf';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+      test('compare not be one of with comma and space separated values should return true', () => {
+        const operator = 'not be one of';
+        const actualValue = 'xyz';
+        const value = 'abc, jkl, opq, sdf';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+      test('compare not be one of with quoted comma-separated values should return true', () => {
+        const operator = 'not be one of';
+        const actualValue = 'x, yz';
+        const value = '"a bc", jkl, "o, pq"';
+        expect(compare(operator, actualValue, value)).toBe(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Basically a map to `Array.includes` and `!Array.includes()`, using a simple string CSV parser as a reliable, familiar way to parse out comma-separated lists.  ...The CSV parser ensures we handle cases where the list of values may itself include commas, or in cases where the values may or may not need to be quoted.