### PR TITLE
changed 'be' and 'not be' in assert function

### DIFF
--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -11,10 +11,23 @@ export interface AssertionResult {
 
 const VALID_OPERATORS = ['be', 'not be', 'contain', 'not contain', 'be greater than', 'be less than', 'be set', 'not be set', 'be one of', 'not be one of'];
 const DATE_TIME_FORMAT = /\d{4}-\d{2}-\d{2}(?:.?\d{2}:\d{2}:\d{2})?/;
+const EMAIL_FORMAT = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 const COMPARERS: Record<string, (actual: any, expected: any) => boolean> = {
-  'be': (actual: any, expected: any) => actual == expected,
-  'not be': (actual: any, expected: any) => actual != expected,
+  'be': (actual: any, expected: any) => {
+    if (EMAIL_FORMAT.test(String(actual).toLowerCase()) && EMAIL_FORMAT.test(String(expected).toLowerCase())) {
+      actual = actual.toString().toLowerCase();
+      expected = expected.toString().toLowerCase();
+    }
+    return actual == expected;
+  },
+  'not be': (actual: any, expected: any) => {
+    if (EMAIL_FORMAT.test(String(actual).toLowerCase()) && EMAIL_FORMAT.test(String(expected).toLowerCase())) {
+      actual = actual.toString().toLowerCase();
+      expected = expected.toString().toLowerCase();
+    }
+    return actual != expected;
+  },
   'contain': (actual: any, expected: any) => !!actual.toLowerCase().includes(expected.toLowerCase()),
   'not contain': (actual: any, expected: any) => !actual.toLowerCase().includes(expected.toLowerCase()),
   'be greater than': (actual: any, expected: any) => {

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -98,6 +98,32 @@ describe('testing assert function', () => {
         expect(assert(operator, undefined, value, field).valid).toBe(false);
       });
     });
+    describe('with email', () => {
+      test('assert be with email value should return true', () => {
+        const operator = 'be';
+        const actualValue = 'TestEmail@Email.com';
+        const value = 'testemail@email.com';
+        expect(assert(operator, actualValue, value, field).valid).toBe(true);
+      });
+      test('assert be with email value should return false', () => {
+        const operator = 'be';
+        const actualValue = 'TestEmail@Email.com';
+        const value = 'nottestemail@email.com';
+        expect(assert(operator, actualValue, value, field).valid).toBe(false);
+      });
+      test('assert not be with email value should return true', () => {
+        const operator = 'not be';
+        const actualValue = 'TestEmail@Email.com';
+        const value = 'nottestemail@email.com';
+        expect(assert(operator, actualValue, value, field).valid).toBe(true);
+      });
+      test('assert not be with email value should return false', () => {
+        const operator = 'not be';
+        const actualValue = 'TestEmail@Email.com';
+        const value = 'testemail@email.com';
+        expect(assert(operator, actualValue, value, field).valid).toBe(false);
+      });
+    });
   });
 
   describe('testing contain and not contain operator', () => {


### PR DESCRIPTION
Changed the 'be' and 'not be' operators in the assert function so that they are not case sensitive when evaluating email addresses.  Four unit tests were added in assert.test.ts to test cases with email addresses.